### PR TITLE
fix: versiom bumper was not work on conflicted

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -111,7 +111,7 @@ if [ -z "${BUMP_LEVEL}" ]; then
 fi
 echo "Bump ${BUMP_LEVEL} version"
 
-git fetch --tags # Fetch existing tags before bump.
+git fetch --tags -f # Fetch existing tags before bump.
 # Fetch history as well because bump uses git history (git tag --merged).
 git fetch --prune --unshallow
 CURRENT_VERSION="$(bump current)" || true


### PR DESCRIPTION
versiom bumper does not work on conflict git tags.

we faced clobber existing tag error.

```
 ! [rejected]        1.12       -> 1.12  (would clobber existing tag)
```

This result display only error.


I think, should override local git tag  by remote one.

