### PR TITLE
skip unshallow if the repo is already unshallowed

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -111,9 +111,15 @@ if [ -z "${BUMP_LEVEL}" ]; then
 fi
 echo "Bump ${BUMP_LEVEL} version"
 
-git fetch --tags -f # Fetch existing tags before bump.
-# Fetch history as well because bump uses git history (git tag --merged).
-git fetch --prune --unshallow
+# check the repository is shallowed.
+# comes from https://stackoverflow.com/questions/37531605/how-to-test-if-git-repository-is-shallow
+if "$(git rev-parse --is-shallow-repository)"; then
+  # the repository is shallowed, so we need to fetch all history.
+  git fetch --tags -f # Fetch existing tags before bump.
+  # Fetch history as well because bump uses git history (git tag --merged).
+  git fetch --prune --unshallow
+fi
+
 CURRENT_VERSION="$(bump current)" || true
 NEXT_VERSION="$(bump ${BUMP_LEVEL})" || true
 


### PR DESCRIPTION
I want to run some scripts before tagging.
e.g. https://github.com/reviewdog/action-actionlint/blob/d3a6e1d60834d9308636d291e53651ba1c2479d7/.github/workflows/release.yml#L30-L37

But I can't make any change in my script because of a permission error.

https://github.com/reviewdog/action-actionlint/runs/3135103508?check_suite_focus=true#step:5:193

```
+ git checkout main -- action.yml
+ perl -i -pe 's(image:\s*["'\'']?Dockerfile["'\'']?)(image: '\''docker://ghcr.io/reviewdog/action-actionlint:v1.5.0'\'')' action.yml
+ git add action.yml
+ git commit -m 'bump v1.5.0'
error: insufficient permission for adding an object to repository database .git/objects
error: insufficient permission for adding an object to repository database .git/objects
error: Error building trees
Error: Process completed with exit code 1.
```

It looks that files created in the docker environment doesn't have enough permission.
This patch stop creating new files by skipping `git fetch` if the repository is already unshallowed.
