### PR TITLE
fix: missing git-lfs from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV BUMP_VERSION=v1.1.0
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
-RUN apk --no-cache add git jq grep curl
+RUN apk --no-cache add git git-lfs jq grep curl
 RUN wget -O - -q https://raw.githubusercontent.com/haya14busa/bump/master/install.sh| sh -s -- -b /usr/local/bin/ ${BUMP_VERSION}
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Added git-lfs to dockerfile. the action breaks when using lfs enabled repo.