### PR TITLE
Support creating tags as a different user

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,20 @@ specific lables (`bump:major`,`bump:minor`,`bump:patch`).
 inputs:
   default_bump_level:
     description: "Default bump level if labels are not attached [major,minor,patch]. Do nothing if it's empty"
+    required: false
   dry_run:
     description: "Do not actually tag next version if it's true"
+    required: false
+  github_token:
+    description: 'GITHUB_TOKEN to list pull requests and create tags'
+    default: '${{ github.token }}'
+    required: true
+  tag_as_user:
+    description: "Name to use when creating tags"
+    required: false
+  tag_as_email:
+    description: "Email address to use when creating tags"
+    required: false
 outputs:
   current_version:
     description: "current version"

--- a/action.yml
+++ b/action.yml
@@ -9,9 +9,15 @@ inputs:
     description: "Do not actually tag next version if it's true"
     required: false
   github_token:
-    description: 'GITHUB_TOKEN to list pull requests'
+    description: 'GITHUB_TOKEN to list pull requests and create tags'
     default: '${{ github.token }}'
     required: true
+  tag_as_user:
+    description: "Name to use when creating tags"
+    required: false
+  tag_as_email:
+    description: "Email address to use when creating tags"
+    required: false
 outputs:
   current_version:
     description: "current version"


### PR DESCRIPTION
- Add a `tag_as_user` input to override the git `user.name` used when creating tags
- Add a `tag_as_email` input to override the git `user.email` used when creating tags
- If a `github_token` has been provided, use that when pushing tags instead of the default Actions token

GitHub Actions won't be triggered for things that use the GITHUB_TOKEN that is automatically generated for each action run - this is to prevent infinite loops. Using a different token for pushing the the tag allows the push to trigger other Actions.