### PR TITLE
Fix a typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # action-bumpr
 
 **action-bumpr** bumps semantic version tag on merging Pull Requests with
-specific lables (`bump:major`,`bump:minor`,`bump:patch`).
+specific labels (`bump:major`,`bump:minor`,`bump:patch`).
 
 ![action-bumpr image](https://user-images.githubusercontent.com/3797062/72686834-dc19a980-3b3b-11ea-9a25-3c5be36d45b1.png)
 


### PR DESCRIPTION
Hello! I found a typo in the README.

Please note that the GitHub project description also needs to be updated.

> ![image](https://github.com/haya14busa/action-bumpr/assets/39996/873b8bbf-3dfa-4838-af4a-eb2ab42751ca)

Thanks for your work on action-bumpr!