### PR TITLE
Run action under default github runner UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,6 @@ RUN wget -O - -q https://raw.githubusercontent.com/haya14busa/bump/master/instal
 
 COPY entrypoint.sh /entrypoint.sh
 
+USER 1001
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN wget -O - -q https://raw.githubusercontent.com/haya14busa/bump/master/instal
 
 COPY entrypoint.sh /entrypoint.sh
 
+# set the runtime user to a non-root user and the same user as used by the github runners for actions runs.
 USER 1001
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This PR adds a `USER` directive to the dockerfile to set the runtime user to a non-root user and the same user as used by the github runners for actions runs. Closes #42